### PR TITLE
Use `ValidationRule` instead of the deprecated `Rule` class

### DIFF
--- a/stubs/app/Actions/Jetstream/AddTeamMember.php
+++ b/stubs/app/Actions/Jetstream/AddTeamMember.php
@@ -53,7 +53,7 @@ class AddTeamMember implements AddsTeamMembers
     /**
      * Get the validation rules for adding a team member.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
      */
     protected function rules(): array
     {


### PR DESCRIPTION
Use `ValidationRule` instead of the deprecated `Rule` class.


When using `enlightn/enlightn` deprecated code warning started to show up - and this seems to be the cause/fix for that.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
